### PR TITLE
Fix unique ids conflicts and alarm control panel broken in HA 2024.11

### DIFF
--- a/custom_components/satel_integra_ext/__init__.py
+++ b/custom_components/satel_integra_ext/__init__.py
@@ -1,6 +1,5 @@
 """Support for Satel Integra devices."""
 import collections
-import logging
 
 from satel_integra_ext.satel_integra import AsyncSatel
 import voluptuous as vol
@@ -12,39 +11,14 @@ from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType
 
-DEFAULT_ALARM_NAME = "satel_integra"
-DEFAULT_PORT = 7094
-DEFAULT_CONF_ARM_HOME_MODE = 1
-DEFAULT_DEVICE_PARTITION = 1
-DEFAULT_ZONE_TYPE = "motion"
-
-_LOGGER = logging.getLogger(__name__)
-
-DOMAIN = "satel_integra_ext"
-
-DATA_SATEL = "satel_integra"
-
-CONF_DEVICE_CODE = "code"
-CONF_DEVICE_PARTITIONS = "partitions"
-CONF_ARM_HOME_MODE = "arm_home_mode"
-CONF_ZONE_NAME = "name"
-CONF_ZONE_TYPE = "type"
-CONF_ZONES = "zones"
-CONF_OUTPUTS = "outputs"
-CONF_TEMP_SENSORS = "temperature_sensors"
-CONF_SWITCHABLE_OUTPUTS = "switchable_outputs"
-CONF_INTEGRATION_KEY = "integration_key"
-CONF_TEMP_SENSOR_NAME = "name"
-
-ZONES = "zones"
-
-SIGNAL_PANEL_MESSAGE = "satel_integra.panel_message"
-SIGNAL_PANEL_ARM_AWAY = "satel_integra.panel_arm_away"
-SIGNAL_PANEL_ARM_HOME = "satel_integra.panel_arm_home"
-SIGNAL_PANEL_DISARM = "satel_integra.panel_disarm"
-
-SIGNAL_ZONES_UPDATED = "satel_integra.zones_updated"
-SIGNAL_OUTPUTS_UPDATED = "satel_integra.outputs_updated"
+from .const import (
+    _LOGGER, DOMAIN, CONF_DEVICE_CODE, CONF_DEVICE_PARTITIONS, CONF_ARM_HOME_MODE,
+    CONF_ZONES, CONF_OUTPUTS, CONF_TEMP_SENSORS, CONF_SWITCHABLE_OUTPUTS, CONF_INTEGRATION_KEY,
+    DEFAULT_PORT, DEFAULT_CONF_ARM_HOME_MODE, DEFAULT_ZONE_TYPE,
+    DATA_SATEL, CONF_DEVICE_CODE, CONF_DEVICE_PARTITIONS, CONF_ARM_HOME_MODE, CONF_ZONE_NAME, CONF_ZONE_TYPE,
+    CONF_ZONES, CONF_OUTPUTS, CONF_TEMP_SENSORS, CONF_SWITCHABLE_OUTPUTS, CONF_INTEGRATION_KEY, CONF_TEMP_SENSOR_NAME,
+    ZONES, SIGNAL_PANEL_MESSAGE, SIGNAL_ZONES_UPDATED, SIGNAL_OUTPUTS_UPDATED
+)
 
 ZONE_SCHEMA = vol.Schema(
     {

--- a/custom_components/satel_integra_ext/alarm_control_panel.py
+++ b/custom_components/satel_integra_ext/alarm_control_panel.py
@@ -7,13 +7,9 @@ from collections import OrderedDict
 from satel_integra_ext.satel_integra import AlarmState
 
 import homeassistant.components.alarm_control_panel as alarm
-from homeassistant.components.alarm_control_panel import AlarmControlPanelEntityFeature
-from homeassistant.const import (
-    STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_ARMED_HOME,
-    STATE_ALARM_DISARMED,
-    STATE_ALARM_PENDING,
-    STATE_ALARM_TRIGGERED,
+from homeassistant.components.alarm_control_panel import (
+    AlarmControlPanelEntityFeature,
+    AlarmControlPanelState,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -28,6 +24,20 @@ from .const import (
     DATA_SATEL,
     SIGNAL_PANEL_MESSAGE,
     _LOGGER
+)
+
+STATE_MAP = OrderedDict(
+    [
+        (AlarmState.TRIGGERED, AlarmControlPanelState.TRIGGERED),
+        (AlarmState.TRIGGERED_FIRE, AlarmControlPanelState.TRIGGERED),
+        (AlarmState.ENTRY_TIME, AlarmControlPanelState.PENDING),
+        (AlarmState.ARMED_MODE3, AlarmControlPanelState.ARMED_HOME),
+        (AlarmState.ARMED_MODE2, AlarmControlPanelState.ARMED_HOME),
+        (AlarmState.ARMED_MODE1, AlarmControlPanelState.ARMED_HOME),
+        (AlarmState.ARMED_MODE0, AlarmControlPanelState.ARMED_HOME),
+        (AlarmState.EXIT_COUNTDOWN_OVER_10, AlarmControlPanelState.PENDING),
+        (AlarmState.EXIT_COUNTDOWN_UNDER_10, AlarmControlPanelState.PENDING),
+    ]
 )
 
 async def async_setup_platform(
@@ -61,7 +71,6 @@ class SatelIntegraAlarmPanel(SatelIntegraEntity, alarm.AlarmControlPanelEntity):
 
     _attr_code_format = alarm.CodeFormat.NUMBER
     _attr_should_poll = False
-    _attr_state: str | None
     _attr_supported_features = (
         AlarmControlPanelEntityFeature.ARM_HOME
         | AlarmControlPanelEntityFeature.ARM_AWAY
@@ -72,11 +81,11 @@ class SatelIntegraAlarmPanel(SatelIntegraEntity, alarm.AlarmControlPanelEntity):
         super().__init__(controller, partition_id, name, "zone")
         self._arm_home_mode = arm_home_mode
         self._device_number = partition_id
+        self._satel_alarm_state = self._read_alarm_state()
 
     async def async_added_to_hass(self) -> None:
         """Update alarm status and register callbacks for future updates."""
         _LOGGER.debug("Starts listening for panel messages")
-        self._update_alarm_status()
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass, SIGNAL_PANEL_MESSAGE, self._update_alarm_status
@@ -88,37 +97,24 @@ class SatelIntegraAlarmPanel(SatelIntegraEntity, alarm.AlarmControlPanelEntity):
         """Handle alarm status update."""
         state = self._read_alarm_state()
         _LOGGER.debug("Got status update, current status: %s", state)
-        if state != self._attr_state:
-            self._attr_state = state
+        if state != self._satel_alarm_state:
+            self._satel_alarm_state = state
             self.async_write_ha_state()
         else:
-            _LOGGER.debug("Ignoring alarm status message, same state")
+           _LOGGER.debug("Ignoring alarm status message, same state")
 
     def _read_alarm_state(self):
         """Read current status of the alarm and translate it into HA status."""
 
         # Default - disarmed:
-        hass_alarm_status = STATE_ALARM_DISARMED
+        hass_alarm_status = AlarmControlPanelState.DISARMED
 
         if not self._satel.connected:
             return None
 
-        state_map = OrderedDict(
-            [
-                (AlarmState.TRIGGERED, STATE_ALARM_TRIGGERED),
-                (AlarmState.TRIGGERED_FIRE, STATE_ALARM_TRIGGERED),
-                (AlarmState.ENTRY_TIME, STATE_ALARM_PENDING),
-                (AlarmState.ARMED_MODE3, STATE_ALARM_ARMED_HOME),
-                (AlarmState.ARMED_MODE2, STATE_ALARM_ARMED_HOME),
-                (AlarmState.ARMED_MODE1, STATE_ALARM_ARMED_HOME),
-                (AlarmState.ARMED_MODE0, STATE_ALARM_ARMED_AWAY),
-                (AlarmState.EXIT_COUNTDOWN_OVER_10, STATE_ALARM_PENDING),
-                (AlarmState.EXIT_COUNTDOWN_UNDER_10, STATE_ALARM_PENDING),
-            ]
-        )
         _LOGGER.debug("State map of Satel: %s", self._satel.partition_states)
 
-        for satel_state, ha_state in state_map.items():
+        for satel_state, ha_state in STATE_MAP.items():
             if (
                 satel_state in self._satel.partition_states
                 and self._device_number in self._satel.partition_states[satel_state]
@@ -134,9 +130,9 @@ class SatelIntegraAlarmPanel(SatelIntegraEntity, alarm.AlarmControlPanelEntity):
             _LOGGER.debug("Code was empty or None")
             return
 
-        clear_alarm_necessary = self._attr_state == STATE_ALARM_TRIGGERED
+        clear_alarm_necessary = self._satel_alarm_state == AlarmControlPanelState.TRIGGERED
 
-        _LOGGER.debug("Disarming, self._attr_state: %s", self._attr_state)
+        _LOGGER.debug("Disarming, self._satel_alarm_state: %s", self._satel_alarm_state)
 
         await self._satel.disarm(code, [self._device_number])
 
@@ -158,3 +154,9 @@ class SatelIntegraAlarmPanel(SatelIntegraEntity, alarm.AlarmControlPanelEntity):
 
         if code:
             await self._satel.arm(code, [self._device_number], self._arm_home_mode)
+
+    @property
+    def alarm_state(self) -> AlarmControlPanelState | None:
+        """Return the state of the entity."""
+        _LOGGER.debug("Getting property alarm_state: %s", self._satel_alarm_state)
+        return self._satel_alarm_state

--- a/custom_components/satel_integra_ext/binary_sensor.py
+++ b/custom_components/satel_integra_ext/binary_sensor.py
@@ -50,7 +50,7 @@ async def async_setup_platform(
         zone_type = device_config_data[CONF_ZONE_TYPE]
         zone_name = device_config_data[CONF_ZONE_NAME]
         device = SatelIntegraBinarySensor(
-            controller, zone_num, zone_name, zone_type, "input", SIGNAL_OUTPUTS_UPDATED
+            controller, zone_num, zone_name, zone_type, "output", SIGNAL_OUTPUTS_UPDATED
         )
         devices.append(device)
 

--- a/custom_components/satel_integra_ext/const.py
+++ b/custom_components/satel_integra_ext/const.py
@@ -1,0 +1,31 @@
+import logging
+
+_LOGGER = logging.getLogger(__package__)
+
+DOMAIN = "satel_integra_ext"
+
+DEFAULT_ALARM_NAME = "satel_integra"
+DEFAULT_PORT = 7094
+DEFAULT_CONF_ARM_HOME_MODE = 1
+DEFAULT_DEVICE_PARTITION = 1
+DEFAULT_ZONE_TYPE = "motion"
+DATA_SATEL = "satel_integra"
+
+CONF_DEVICE_CODE = "code"
+CONF_DEVICE_PARTITIONS = "partitions"
+CONF_ARM_HOME_MODE = "arm_home_mode"
+CONF_ZONE_NAME = "name"
+CONF_ZONE_TYPE = "type"
+CONF_ZONES = "zones"
+CONF_OUTPUTS = "outputs"
+CONF_TEMP_SENSORS = "temperature_sensors"
+CONF_SWITCHABLE_OUTPUTS = "switchable_outputs"
+CONF_INTEGRATION_KEY = "integration_key"
+CONF_TEMP_SENSOR_NAME = "name"
+ZONES = "zones"
+SIGNAL_PANEL_MESSAGE = "satel_integra.panel_message"
+SIGNAL_PANEL_ARM_AWAY = "satel_integra.panel_arm_away"
+SIGNAL_PANEL_ARM_HOME = "satel_integra.panel_arm_home"
+SIGNAL_PANEL_DISARM = "satel_integra.panel_disarm"
+SIGNAL_ZONES_UPDATED = "satel_integra.zones_updated"
+SIGNAL_OUTPUTS_UPDATED = "satel_integra.outputs_updated"

--- a/custom_components/satel_integra_ext/entity.py
+++ b/custom_components/satel_integra_ext/entity.py
@@ -1,0 +1,31 @@
+"""Support for Satel Integra modifiable outputs represented as switches."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.helpers.entity import Entity
+
+from .const import (
+    DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+class SatelIntegraEntity(Entity):
+    """Base class for Satel entities."""
+
+    _attr_should_poll = False
+
+    def __init__(self, controller, device_number, device_name, device_type):
+        """Initialize the binary_sensor."""
+        self._device_number = device_number
+        self._name = device_name
+        self._satel = controller
+        self._device_type = device_type
+        self._attr_unique_id = f"${DOMAIN}.{device_type}${device_number}"
+        _LOGGER.info("SatelIntegraEntity.__init__ ### %s - %s", self._attr_unique_id, self._name)
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return self._name

--- a/custom_components/satel_integra_ext/sensor.py
+++ b/custom_components/satel_integra_ext/sensor.py
@@ -9,9 +9,12 @@ from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from . import (
+
+from .entity import SatelIntegraEntity
+from .const import (
     DATA_SATEL,
-    DOMAIN, CONF_TEMP_SENSORS, CONF_TEMP_SENSOR_NAME,
+    CONF_TEMP_SENSORS,
+    CONF_TEMP_SENSOR_NAME,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,7 +39,7 @@ async def async_setup_platform(
 PARALLEL_UPDATES = 0
 SCAN_INTERVAL = timedelta(seconds=120)
 
-class SatelIntegraTemperatureSensor(SensorEntity):
+class SatelIntegraTemperatureSensor(SatelIntegraEntity, SensorEntity):
     """Representation of an Satel Integra temperature sensor."""
 
     _attr_device_class = SensorDeviceClass.TEMPERATURE
@@ -47,15 +50,7 @@ class SatelIntegraTemperatureSensor(SensorEntity):
         self, controller, device_number, device_name
     ):
         """Initialize the sensor."""
-        self._name = device_name
-        self._attr_unique_id = f"${DOMAIN}.temp${device_number}"
-        self._device_number = device_number
-        self._satel = controller
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return self._name
+        super().__init__(controller, device_number, device_name, "temp")
 
     async def async_update(self) -> None:
         # generate random temperature between 20.5 and 22.5

--- a/custom_components/satel_integra_ext/switch.py
+++ b/custom_components/satel_integra_ext/switch.py
@@ -9,14 +9,13 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-
+from .entity import SatelIntegraEntity
 from . import (
     CONF_DEVICE_CODE,
     CONF_SWITCHABLE_OUTPUTS,
     CONF_ZONE_NAME,
     DATA_SATEL,
-    SIGNAL_OUTPUTS_UPDATED,
-    DOMAIN,
+    SIGNAL_OUTPUTS_UPDATED
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,23 +44,22 @@ async def async_setup_platform(
         device = SatelIntegraSwitch(
             controller, zone_num, zone_name, discovery_info[CONF_DEVICE_CODE]
         )
+
         devices.append(device)
 
     async_add_entities(devices)
 
-class SatelIntegraSwitch(SwitchEntity):
+
+class SatelIntegraSwitch(SatelIntegraEntity, SwitchEntity):
     """Representation of an Satel switch."""
 
     _attr_should_poll = False
 
     def __init__(self, controller, device_number, device_name, code):
         """Initialize the binary_sensor."""
-        self._device_number = device_number
-        self._name = device_name
+        super().__init__(controller, device_number, device_name, "output") # should be "switch")
         self._state = False
         self._code = code
-        self._satel = controller
-        self._attr_unique_id = f"${DOMAIN}.output${device_number}"
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
@@ -103,8 +101,3 @@ class SatelIntegraSwitch(SwitchEntity):
     def _read_state(self):
         """Read state of the device."""
         return self._device_number in self._satel.violated_outputs
-
-    @property
-    def name(self):
-        """Return the name of the switch."""
-        return self._name


### PR DESCRIPTION
**Caution: this version requires Home Assistant 2024.11 or higher!**

- fixed conflicts between zones and non-switchable outputs with the same device numbers
- adopt AlarmControlPanel to HA 2024.11 changes (and coming 2025.11 changes)